### PR TITLE
Corrected spawning of animals/monsters through AutoSpawner

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -1,4 +1,7 @@
 # Default Config File for PureEntitiesX
-# most of them ar at pocketmine.yml
-# only explodeBlocks can by contolt
-explodeBlocks: false
+creeper:
+  block-breaking-explosion: false # when set to true the creeper will explode and also burst blocks
+
+# control logfile logging
+logfile:
+  loglevel: info # possible: debug, info, warn

--- a/src/revivalpmmp/pureentities/task/AutoDespawnTask.php
+++ b/src/revivalpmmp/pureentities/task/AutoDespawnTask.php
@@ -17,6 +17,7 @@ class AutoDespawnTask extends PluginTask {
     }
     
     public function onRun($currentTick){
+        PureEntities::logDebug("AutoDespawnTask: onRun ($currentTick)");
         $despawnable = [];
         foreach($this->plugin->getServer()->getLevels() as $level) {
             foreach($level->getEntities() as $entity) {
@@ -33,12 +34,14 @@ class AutoDespawnTask extends PluginTask {
                     $probability = mt_rand(1, 100);
                     if($probability === 1) {
                         if($entity instanceof Monster) {
+                            PureEntities::logDebug("AutoDespawnTask: close monster entity (id: ". $entity->getId() . ", name:" . $entity->getNameTag() .")");
                             $entity->close();
                         }
                     }
                     
                 } elseif($despawnable[$entity->getId()] === 3) {
                     if($entity instanceof Animal || $entity instanceof Monster) {
+                        PureEntities::logDebug("AutoDespawnTask: close animal/monster entity (id: ". $entity->getId() . ", name:" . $entity->getNameTag() .")");
                         $entity->close();
                     }
                 }


### PR DESCRIPTION
It happens a lot, that Animal Entities get stuck while spawned (inside of solid). When i teleported to the coordinates where the spawn happened - I got stuck too. So, I took the liberty to change the spawning code a bit. Now they're spawning "outside of solid".

Still, the entity count is wrong. This needs some refactoring. I will do this with the next pull request.

This Pull Request has been roughly tested with 1.0.0-bug-fixes branch on my personal Server running 1.0 PocketMine-MP.

Here the changes (summarized):
- loglevel of the logfile is now configurable
- added some log output in the logfile for better bugfixing
- changed spawning positions for animals and monsters

