### PR TITLE
Bugfix sheep Color/Sheared also when reloaded from NBT data

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -7,3 +7,22 @@ load: STARTUP
 authors: ["milk0417", "RevivalPMMP"]
 description: Implement all MCPE entities into your worlds
 website: https://github.com/RevivalPMMP/PureEntitiesX
+
+commands:
+  summon:
+    description: Summons a creature
+    usage: "/summon <mob>"
+    permission: pureentities.command.summon
+
+permissions:
+ pureentities:
+  default: op
+  description: "Allows using all the PureEntities commands"
+  children:
+    pureentities.command:
+    default: op
+    description: "Allows using all the PureEntities commands"
+    children:
+      pureentities.command.summon:
+      default: op
+      description: "Allows spawning mobs"

--- a/src/revivalpmmp/pureentities/PureEntities.php
+++ b/src/revivalpmmp/pureentities/PureEntities.php
@@ -23,8 +23,6 @@ use pocketmine\command\CommandExecutor;
 use pocketmine\command\CommandSender;
 use pocketmine\Player;
 use revivalpmmp\pureentities\entity\animal\swimming\Squid;
-use revivalpmmp\pureentities\entity\monster\swimming\Guardian;
-use revivalpmmp\pureentities\entity\monster\swimming\ElderGuardian;
 use revivalpmmp\pureentities\entity\monster\jumping\MagmaCube;
 use revivalpmmp\pureentities\entity\monster\jumping\Slime;
 use revivalpmmp\pureentities\entity\animal\walking\Villager;
@@ -73,6 +71,7 @@ use pocketmine\nbt\tag\FloatTag;
 use pocketmine\plugin\PluginBase;
 use pocketmine\tile\Tile;
 use pocketmine\utils\TextFormat;
+use revivalpmmp\pureentities\tile\Spawner;
 
 class PureEntities extends PluginBase implements CommandExecutor {
 
@@ -98,7 +97,7 @@ class PureEntities extends PluginBase implements CommandExecutor {
     }
 
     public function onLoad(){
-        $classes = [
+        self::$registeredClasses = [
             Stray::class,
             Husk::class,
             Horse::class,
@@ -226,8 +225,12 @@ class PureEntities extends PluginBase implements CommandExecutor {
             return false;
         } else {
             $entity = self::create($entityid, $pos);
-            $entity->spawnToAll();
-            return true;
+            if ($entity !== null) {
+                $entity->spawnToAll();
+                return true;
+            }
+            self::logOutput("Cannot create entity [entityId:$entityid]", self::WARN);
+            return false;
         }
     }
 

--- a/src/revivalpmmp/pureentities/PureEntities.php
+++ b/src/revivalpmmp/pureentities/PureEntities.php
@@ -18,10 +18,16 @@
 
 namespace revivalpmmp\pureentities;
 
+use pocketmine\command\Command;
+use pocketmine\command\CommandExecutor;
+use pocketmine\command\CommandSender;
 use pocketmine\entity\Ageable;
 use pocketmine\Player;
+use pocketmine\Server;
 use revivalpmmp\pureentities\entity\animal\flying\Bat;
 use revivalpmmp\pureentities\entity\animal\swimming\Squid;
+use revivalpmmp\pureentities\entity\BaseEntity;
+use revivalpmmp\pureentities\entity\monster\Monster;
 use revivalpmmp\pureentities\entity\monster\swimming\Guardian;
 use revivalpmmp\pureentities\entity\monster\swimming\ElderGuardian;
 use revivalpmmp\pureentities\entity\monster\jumping\MagmaCube;
@@ -76,7 +82,7 @@ use pocketmine\plugin\PluginBase;
 use pocketmine\tile\Tile;
 use pocketmine\utils\TextFormat;
 
-class PureEntities extends PluginBase {
+class PureEntities extends PluginBase implements CommandExecutor {
 
     /** @var  PureEntities $instance */
     private static $instance;
@@ -87,18 +93,20 @@ class PureEntities extends PluginBase {
     // logging constants for method call 'logOutput'
     const NORM = 0;
     const WARN = 1;
-	const DEBUG = 2;
+    const DEBUG = 2;
+
+    private static $registeredClasses = [];
 
     /**
      * Returns the plugin instance to get access to config e.g.
      * @return PureEntities the current instance of the plugin main class
      */
-    public static function getInstance() : PureEntities {
+    public static function getInstance(): PureEntities {
         return PureEntities::$instance;
     }
 
-    public function onLoad(){
-        $classes = [
+    public function onLoad() {
+        self::$registeredClasses = [
             Stray::class,
             Husk::class,
             Horse::class,
@@ -135,24 +143,24 @@ class PureEntities extends PluginBase {
             ZombieVillager::class,
             FireBall::class
         ];
-        foreach($classes as $name){
+        foreach (self::$registeredClasses as $name) {
             Entity::registerEntity($name);
-            if(
+            if (
                 $name == IronGolem::class
                 || $name == FireBall::class
                 || $name == SnowGolem::class
                 || $name == ZombieVillager::class
-            ){
+            ) {
                 continue;
             }
             $item = Item::get(Item::SPAWN_EGG, $name::NETWORK_ID);
-            if(!Item::isCreativeItem($item)){
+            if (!Item::isCreativeItem($item)) {
                 Item::addCreativeItem($item);
             }
         }
 
- 		self::registerTile(Spawner::class);
-        
+        Tile::registerTile(Spawner::class);
+
         $this->getServer()->getLogger()->info(TextFormat::GOLD . "[PureEntitiesX] The Original Code for this Plugin was Written by milk0417. It is now being maintained by RevivalPMMP for PMMP 'Unleashed'.");
 
         PureEntities::$loglevel = strtolower($this->getConfig()->getNested("logfile.loglevel", 0));
@@ -161,17 +169,17 @@ class PureEntities extends PluginBase {
         PureEntities::$instance = $this;
     }
 
-    public function onEnable(){
+    public function onEnable() {
         $this->getServer()->getPluginManager()->registerEvents(new EventListener($this), $this);
         $this->saveDefaultConfig();
         $this->reloadConfig();
         $this->getServer()->getScheduler()->scheduleRepeatingTask(new AutoDespawnTask($this), $this->getConfig()->getNested("despawn-task.trigger-ticks", 1000));
         $this->getServer()->getScheduler()->scheduleRepeatingTask(new AutoSpawnTask($this), $this->getConfig()->getNested("spawn-task.trigger-ticks", 1000));
-	    $this->getServer()->getLogger()->notice("Enabled!");
-	    $this->getServer()->getLogger()->notice("You're Running ".$this->getDescription()->getFullName());
+        $this->getServer()->getLogger()->notice("Enabled!");
+        $this->getServer()->getLogger()->notice("You're Running " . $this->getDescription()->getFullName());
     }
 
-    public function onDisable(){
+    public function onDisable() {
         $this->getServer()->getLogger()->notice("Disabled!");
     }
 
@@ -179,15 +187,15 @@ class PureEntities extends PluginBase {
      * @param int|string $type
      * @param Position $source
      * @param $args
-     * 
+     *
      * @return Entity
      */
-    public static function create($type, Position $source, ...$args){
+    public static function create($type, Position $source, ...$args) {
         $chunk = $source->getLevel()->getChunk($source->x >> 4, $source->z >> 4, true);
-        if(!$chunk->isGenerated()){
+        if (!$chunk->isGenerated()) {
             $chunk->setGenerated();
         }
-        if(!$chunk->isPopulated()){
+        if (!$chunk->isPopulated()) {
             $chunk->setPopulated();
         }
 
@@ -209,18 +217,18 @@ class PureEntities extends PluginBase {
         ]);
         return Entity::createEntity($type, $chunk, $nbt, ...$args);
     }
-    
+
     /**
      * @param Position $pos
      * @param int $entityid
      * @param Level $level
      * @param string $type
-     * 
+     *
      * @return boolean
      */
     public function scheduleCreatureSpawn(Position $pos, int $entityid, Level $level, string $type) {
         $this->getServer()->getPluginManager()->callEvent($event = new CreatureSpawnEvent($this, $pos, $entityid, $level, $type));
-        if($event->isCancelled()) {
+        if ($event->isCancelled()) {
             return false;
         } else {
             $entity = self::create($entityid, $pos);
@@ -229,67 +237,67 @@ class PureEntities extends PluginBase {
         }
     }
 
-    public function checkEntityCount(string $type, $water = false) : bool {
-    	$i = 0;
-    	foreach ($this->getServer()->getLevels() as $level) {
-    		foreach ($level->getEntities() as $entity) {
-    			if(!$entity instanceof Player) {
-    				$i++;
-			    }
-		    }
-	    }
-	    if(strpos(strtolower($type),"animal")) {
-    		if($water == true) {
-			    if($i < $this->getServer()->getProperty("water-animals",5)) {
-			        self::logOutput("checkEntityCount for water returns true",self::DEBUG);
-				    return true;
-			    }
-		    }else{
-			    if($i < $this->getServer()->getProperty("animals",70)) {
-				    self::logOutput("checkEntityCount for animals returns true",self::DEBUG);
-				    return true;
-			    }
-		    }
-	    }else{
-		    if($i < $this->getServer()->getProperty("monsters",70)) {
-			    self::logOutput("checkEntityCount for monsters returns true",self::DEBUG);
-			    return true;
-		    }
-	    }
-	    self::logOutput("checkEntityCount returns false",self::DEBUG);
-	    return false;
+    public function checkEntityCount(string $type, $water = false): bool {
+        $i = 0;
+        foreach ($this->getServer()->getLevels() as $level) {
+            foreach ($level->getEntities() as $entity) {
+                if (!$entity instanceof Player) {
+                    $i++;
+                }
+            }
+        }
+        if (strpos(strtolower($type), "animal")) {
+            if ($water == true) {
+                if ($i < $this->getServer()->getProperty("water-animals", 5)) {
+                    self::logOutput("checkEntityCount for water returns true", self::DEBUG);
+                    return true;
+                }
+            } else {
+                if ($i < $this->getServer()->getProperty("animals", 70)) {
+                    self::logOutput("checkEntityCount for animals returns true", self::DEBUG);
+                    return true;
+                }
+            }
+        } else {
+            if ($i < $this->getServer()->getProperty("monsters", 70)) {
+                self::logOutput("checkEntityCount for monsters returns true", self::DEBUG);
+                return true;
+            }
+        }
+        self::logOutput("checkEntityCount returns false", self::DEBUG);
+        return false;
     }
 
 
-	/**
-	 * Logs an output to the plugin's logfile ...
-	 * @param string $logline   the output to be appended
-	 * @param int $type         the type of output to log
-	 * @return int|bool         returns false on failure
-	 */
-	public static function logOutput(string $logline, int $type) {
-		switch($type) {
-			case self::DEBUG:
-			    if (strcmp(self::$loglevel, "debug") == 0) {
+    /**
+     * Logs an output to the plugin's logfile ...
+     * @param string $logline the output to be appended
+     * @param int $type the type of output to log
+     * @return int|bool         returns false on failure
+     */
+    public static function logOutput(string $logline, int $type) {
+        switch ($type) {
+            case self::DEBUG:
+                if (strcmp(self::$loglevel, "debug") == 0) {
                     file_put_contents('./pureentities_' . date("j.n.Y") . '.log', "\033[32m" . (date("j.n.Y G:i:s") . " [DEBUG] " . $logline . "\033[0m\r\n"), FILE_APPEND);
                 }
-				break;
-			case self::WARN:
+                break;
+            case self::WARN:
                 file_put_contents('./pureentities_' . date("j.n.Y") . '.log', "\033[31m" . (date("j.n.Y G:i:s") . " [WARN]  " . $logline . "\033[0m\r\n"), FILE_APPEND);
-				break;
-			case self::NORM:
+                break;
+            case self::NORM:
                 file_put_contents('./pureentities_' . date("j.n.Y") . '.log', "\033[37m" . (date("j.n.Y G:i:s") . " [INFO]  " . $logline . "\033[0m\r\n"), FILE_APPEND);
-				break;
-			default:
-				if(strcmp(self::$loglevel, "debug") == 0) {
-					file_put_contents('./pureentities_' . date("j.n.Y") . '.log', "\033[32m" . (date("j.n.Y G:i:s") . " [DEBUG] " . $logline . "\033[0m\r\n"), FILE_APPEND);
-				} elseif(strcmp(self::$loglevel, "warn") == 0) {
-					file_put_contents('./pureentities_'.date("j.n.Y").'.log', "\033[31m".(date("j.n.Y G:i:s")." [WARN]  ".$logline."\033[0m\r\n"), FILE_APPEND);
-				}else{
-					file_put_contents('./pureentities_' . date("j.n.Y") . '.log', "\033[37m" . (date("j.n.Y G:i:s") . " [INFO]  " . $logline . "\033[0m\r\n"), FILE_APPEND);
-				}
-		}
-	}
+                break;
+            default:
+                if (strcmp(self::$loglevel, "debug") == 0) {
+                    file_put_contents('./pureentities_' . date("j.n.Y") . '.log', "\033[32m" . (date("j.n.Y G:i:s") . " [DEBUG] " . $logline . "\033[0m\r\n"), FILE_APPEND);
+                } elseif (strcmp(self::$loglevel, "warn") == 0) {
+                    file_put_contents('./pureentities_' . date("j.n.Y") . '.log', "\033[31m" . (date("j.n.Y G:i:s") . " [WARN]  " . $logline . "\033[0m\r\n"), FILE_APPEND);
+                } else {
+                    file_put_contents('./pureentities_' . date("j.n.Y") . '.log', "\033[37m" . (date("j.n.Y G:i:s") . " [INFO]  " . $logline . "\033[0m\r\n"), FILE_APPEND);
+                }
+        }
+    }
 
     /**
      * Returns the first position of block of AIR found at above the given coordinates.
@@ -297,13 +305,13 @@ class PureEntities extends PluginBase {
      * Sometimes it seems that getHighestBlockAt is not working properly. So i introduced this additional
      * method.
      *
-     * @param int $x        the x coordinate
-     * @param int $y        the y coordinate (which is used in +1 until an AIR block is found)
-     * @param int $z        the z coordinate
-     * @param Level $level  the level to search in
+     * @param int $x the x coordinate
+     * @param int $y the y coordinate (which is used in +1 until an AIR block is found)
+     * @param int $z the z coordinate
+     * @param Level $level the level to search in
      * @return Position     the Position of the first AIR block found above given coordinates
      */
-    public static function getFirstAirAbovePosition ($x, $y, $z, Level $level) : Position {
+    public static function getFirstAirAbovePosition($x, $y, $z, Level $level): Position {
         $air = false;
         $newPosition = null;
         while (!$air) {
@@ -317,4 +325,59 @@ class PureEntities extends PluginBase {
         }
         return $newPosition;
     }
+
+    /**
+     * @param CommandSender $sender
+     * @param Command $cmd
+     * @param string $label
+     * @param array $args
+     * @return bool
+     */
+    public function onCommand(CommandSender $sender, Command $command, $label, array $args) {
+        switch($command->getName()){
+            case "summon":
+                if (count($args) == 1) {
+                    $playerName = $sender->getName();
+                    foreach ($this->getServer()->getOnlinePlayers() as $player) {
+                        if (strcmp($player->getName(), $playerName) == 0) {
+                            // find a mob with the name issued
+                            $mobName = strtolower($args[0]);
+                            foreach (self::$registeredClasses as $registeredClass) {
+                                if (strcmp($mobName, strtolower($this->getShortClassName($registeredClass))) == 0) {
+                                    self::scheduleCreatureSpawn($player->getPosition(), $registeredClass::NETWORK_ID, $player->getLevel(), "Monster");
+                                    $sender->sendMessage("Spawned $mobName");
+                                    return true;
+                                }
+                            }
+                            $sender->sendMessage("Entity not found: $mobName");
+                            return true;
+                        }
+                    }
+                } else {
+                    $sender->sendMessage("Need a mob name!");
+                    return true;
+                }
+                break;
+            default:
+                break;
+        }
+        return false;
+    }
+
+    /**
+     * Returns the "short" name of a class without namespace ...
+     *
+     * @param string $longClassName
+     * @return string
+     */
+    private function getShortClassName (string $longClassName) : string {
+        $longClassName = strtok ($longClassName , "\\");
+        while ($longClassName !== false) {
+            $short = $longClassName;
+            $longClassName = strtok("\\");
+        }
+        return $short;
+    }
 }
+
+

--- a/src/revivalpmmp/pureentities/entity/animal/flying/Bat.php
+++ b/src/revivalpmmp/pureentities/entity/animal/flying/Bat.php
@@ -16,19 +16,16 @@ class Bat extends FlyingAnimal{
         return "Bat";
     }
 
-    public function initEntity(){
-        parent::initEntity();
-
-        $this->setMaxHealth(6);
-        $this->setHealth(6);
-    }
-
     public function targetOption(Creature $creature, float $distance) : bool{
         return false;
     }
 
     public function getDrops(){
         return [];
+    }
+
+    public function getMaxHealth() {
+        return 6;
     }
 
 }

--- a/src/revivalpmmp/pureentities/entity/animal/walking/Chicken.php
+++ b/src/revivalpmmp/pureentities/entity/animal/walking/Chicken.php
@@ -18,13 +18,6 @@ class Chicken extends WalkingAnimal{
         return "Chicken";
     }
 
-    public function initEntity(){
-        parent::initEntity();
-
-        $this->setMaxHealth(4);
-        $this->setHealth(4);
-    }
-
     public function targetOption(Creature $creature, float $distance) : bool{
         if($creature instanceof Player){
             return $creature->isAlive() && !$creature->closed && $creature->getInventory()->getItemInHand()->getId() == Item::SEEDS && $distance <= 49;
@@ -41,6 +34,10 @@ class Chicken extends WalkingAnimal{
           array_push($drops, Item::get(Item::RAW_CHICKEN, 0, 1));
         }
         return $drops;
+    }
+
+    public function getMaxHealth() {
+        return 4;
     }
 
 }

--- a/src/revivalpmmp/pureentities/entity/animal/walking/Cow.php
+++ b/src/revivalpmmp/pureentities/entity/animal/walking/Cow.php
@@ -18,13 +18,6 @@ class Cow extends WalkingAnimal{
         return "Cow";
     }
 
-    public function initEntity(){
-        parent::initEntity();
-
-        $this->setMaxHealth(10);
-        $this->setHealth(10);
-    }
-
     public function targetOption(Creature $creature, float $distance) : bool{
         if($creature instanceof Player){
             return $creature->isAlive() && !$creature->closed && $creature->getInventory()->getItemInHand()->getId() == Item::WHEAT && $distance <= 49;
@@ -41,5 +34,9 @@ class Cow extends WalkingAnimal{
           array_push($drops, Item::get(Item::RAW_BEEF, 0, mt_rand(1, 3)));
         }
         return $drops;
+    }
+
+    public function getMaxHealth() {
+        return 10;
     }
 }

--- a/src/revivalpmmp/pureentities/entity/animal/walking/Donkey.php
+++ b/src/revivalpmmp/pureentities/entity/animal/walking/Donkey.php
@@ -18,13 +18,6 @@ class Donkey extends WalkingAnimal implements Rideable{
         return "Donkey";
     }
 
-    public function initEntity(){
-        parent::initEntity();
-
-        $this->setMaxHealth(20);
-        $this->setHealth(20);
-    }
-
     public function targetOption(Creature $creature, float $distance) : bool{
         if($creature instanceof Player){
             return $creature->spawned && $creature->isAlive() && !$creature->closed && $creature->getInventory()->getItemInHand()->getId() == Item::WHEAT && $distance <= 49;
@@ -34,6 +27,10 @@ class Donkey extends WalkingAnimal implements Rideable{
 
     public function getDrops(){
         return [Item::get(Item::LEATHER, 0, mt_rand(0,2))];
+    }
+
+    public function getMaxHealth() {
+        return 20;
     }
 
 }

--- a/src/revivalpmmp/pureentities/entity/animal/walking/Horse.php
+++ b/src/revivalpmmp/pureentities/entity/animal/walking/Horse.php
@@ -18,13 +18,6 @@ class Horse extends WalkingAnimal implements Rideable{
         return "Horse";
     }
 
-    public function initEntity(){
-        parent::initEntity();
-
-        $this->setMaxHealth(20);
-        $this->setHealth(20);
-    }
-
     public function targetOption(Creature $creature, float $distance) : bool{
         if($creature instanceof Player){
             return $creature->spawned && $creature->isAlive() && !$creature->closed && $creature->getInventory()->getItemInHand()->getId() == Item::APPLE && $distance <= 49;
@@ -34,6 +27,10 @@ class Horse extends WalkingAnimal implements Rideable{
 
     public function getDrops(){
         return [Item::get(Item::LEATHER, 0, mt_rand(0, 2))];
+    }
+
+    public function getMaxHealth() {
+        return 20;
     }
 
 }

--- a/src/revivalpmmp/pureentities/entity/animal/walking/Mooshroom.php
+++ b/src/revivalpmmp/pureentities/entity/animal/walking/Mooshroom.php
@@ -17,13 +17,6 @@ class Mooshroom extends WalkingAnimal{
         return "Mooshroom";
     }
 
-    public function initEntity(){
-        parent::initEntity();
-
-        $this->setMaxHealth(10);
-        $this->setHealth(10);
-    }
-
     public function targetOption(Creature $creature, float $distance) : bool{
         if($creature instanceof Player){
             return $creature->spawned && $creature->isAlive() && !$creature->closed && $creature->getInventory()->getItemInHand()->getId() == Item::WHEAT && $distance <= 49;
@@ -40,5 +33,9 @@ class Mooshroom extends WalkingAnimal{
         array_push($drops, Item::get(Item::RAW_BEEF, 0, mt_rand(1, 3)));
       }
       return $drops;
+    }
+
+    public function getMaxHealth() {
+        return 10;
     }
 }

--- a/src/revivalpmmp/pureentities/entity/animal/walking/Mule.php
+++ b/src/revivalpmmp/pureentities/entity/animal/walking/Mule.php
@@ -18,13 +18,6 @@ class Mule extends WalkingAnimal implements Rideable{
         return "Mule";
     }
 
-    public function initEntity(){
-        parent::initEntity();
-
-        $this->setMaxHealth(15);
-        $this->setHealth(15);
-    }
-
     public function targetOption(Creature $creature, float $distance) : bool{
         if($creature instanceof Player){
             return $creature->spawned && $creature->isAlive() && !$creature->closed && $creature->getInventory()->getItemInHand()->getId() == Item::WHEAT && $distance <= 49;
@@ -34,6 +27,10 @@ class Mule extends WalkingAnimal implements Rideable{
 
     public function getDrops(){
         return [Item::get(Item::LEATHER, 0, mt_rand(0, 2))];
+    }
+
+    public function getMaxHealth() {
+        return 15;
     }
 
 }

--- a/src/revivalpmmp/pureentities/entity/animal/walking/Ocelot.php
+++ b/src/revivalpmmp/pureentities/entity/animal/walking/Ocelot.php
@@ -17,13 +17,6 @@ class Ocelot extends WalkingAnimal{
         return 1.4;
     }
 
-    public function initEntity(){
-        parent::initEntity();
-
-        $this->setMaxHealth(10);
-        $this->setHealth(10);
-    }
-
     public function getName(){
         return "Ocelot";
     }
@@ -37,5 +30,9 @@ class Ocelot extends WalkingAnimal{
 
     public function getDrops(){
         return [];
+    }
+
+    public function getMaxHealth() {
+        return 10;
     }
 }

--- a/src/revivalpmmp/pureentities/entity/animal/walking/Pig.php
+++ b/src/revivalpmmp/pureentities/entity/animal/walking/Pig.php
@@ -19,13 +19,6 @@ class Pig extends WalkingAnimal implements Rideable {
         return "Pig";
     }
 
-    public function initEntity(){
-        parent::initEntity();
-
-        $this->setMaxHealth(10);
-        $this->setHealth(10);
-    }
-
     public function targetOption(Creature $creature, float $distance) : bool{
         if($creature instanceof Player){
             return $creature->spawned && $creature->isAlive() && !$creature->closed && $creature->getInventory()->getItemInHand()->getId() == Item::CARROT && $distance <= 49;
@@ -39,6 +32,10 @@ class Pig extends WalkingAnimal implements Rideable {
         } else {
           return [Item::get(Item::RAW_PORKCHOP, 0, mt_rand(1, 3))];
         }
+    }
+
+    public function getMaxHealth() {
+        return 10;
     }
 
 }

--- a/src/revivalpmmp/pureentities/entity/animal/walking/Rabbit.php
+++ b/src/revivalpmmp/pureentities/entity/animal/walking/Rabbit.php
@@ -25,13 +25,6 @@ class Rabbit extends WalkingAnimal {
         return "Rabbit";
     }
 
-    public function initEntity(){
-        parent::initEntity();
-
-        $this->setMaxHealth(3);
-        $this->setHealth(3);
-    }
-
     public function targetOption(Creature $creature, float $distance) : bool{
         if($creature instanceof Player){
             return $creature->spawned && $creature->isAlive() && !$creature->closed && $creature->getInventory()->getItemInHand()->getId() == Item::SEEDS && $distance <= 49;
@@ -41,6 +34,10 @@ class Rabbit extends WalkingAnimal {
 
     public function getDrops(){
         return [];
+    }
+
+    public function getMaxHealth() {
+        return 3;
     }
 
 }

--- a/src/revivalpmmp/pureentities/entity/animal/walking/Sheep.php
+++ b/src/revivalpmmp/pureentities/entity/animal/walking/Sheep.php
@@ -2,14 +2,12 @@
 
 namespace revivalpmmp\pureentities\entity\animal\walking;
 
-use pocketmine\Server;
+use pocketmine\entity\Entity;
 use revivalpmmp\pureentities\entity\animal\WalkingAnimal;
 use pocketmine\entity\Colorable;
 use pocketmine\item\Item;
 use pocketmine\Player;
 use pocketmine\entity\Creature;
-use pocketmine\level\format\Chunk as FullChunk;
-use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\nbt\tag\ByteTag;
 use revivalpmmp\pureentities\data\Data;
 
@@ -35,6 +33,9 @@ class Sheep extends WalkingAnimal {
 	const RED = 14;
 	const BLACK = 15;
 
+	const NBT_KEY_COLOR = "Color";
+	const NBT_KEY_SHEARED = "Sheared";
+
     public $width = 0.625;
 	public $length = 1.4375;
 	public $height = 1.8;
@@ -42,14 +43,6 @@ class Sheep extends WalkingAnimal {
     public function getName(){
         return "Sheep";
     }
-
-    public function __construct(FullChunk $chunk, CompoundTag $nbt){
-		if(!isset($nbt->Color)){
-			$nbt->Color = new ByteTag("Color", self::getRandomColor());
-		}
-		parent::__construct($chunk, $nbt);
-		$this->setDataProperty(self::DATA_COLOUR, self::DATA_TYPE_BYTE, self::getColor());
-	}
 
     public static function getRandomColor() : int {
 		$rand = "";
@@ -71,18 +64,11 @@ class Sheep extends WalkingAnimal {
 		return intval($arr[mt_rand(0, count($arr) - 1)]);
 	}
 
-	public function getColor() : int {
-		return (int) $this->namedtag["Color"];
-	}
-
-	public function setColor(int $color){
-		$this->namedtag->Color = new ByteTag("Color", $color);
-	}
-
     public function initEntity(){
         parent::initEntity();
-        $this->setMaxHealth(8);
-        $this->setHealth(8);
+
+        $this->setColor($this->getColor());
+        $this->setSheared ($this->isSheared());
     }
 
     public function targetOption(Creature $creature, float $distance) : bool {
@@ -104,6 +90,62 @@ class Sheep extends WalkingAnimal {
             $drops = [Item::get(Item::WOOL, self::getColor(), mt_rand(0, 2))];
         }
         return $drops;
+    }
+
+    /**
+     * The initEntity method of parent uses this function to get the max healthand set in NBT
+     *
+     * @return int
+     */
+    public function getMaxHealth(){
+        return 8;
+    }
+
+
+    // ------------------------------------------------------------
+    // very sheep specific functions
+    // ------------------------------------------------------------
+    /**
+     * Checks if this entity is sheared
+     * @return bool
+     */
+    public function isSheared () : bool {
+        if (!isset($this->namedtag->Sheared)) {
+            $this->namedtag->Sheared = new ByteTag(self::NBT_KEY_SHEARED, 0); // set not sheared
+        }
+        return (bool) $this->namedtag[self::NBT_KEY_SHEARED];
+    }
+
+    /**
+     * Sets this entity sheared or not
+     *
+     * @param bool $sheared
+     */
+    public function setSheared (bool $sheared) {
+        $this->namedtag->Sheared = new ByteTag(self::NBT_KEY_SHEARED, $sheared); // update NBT
+        $this->setDataFlag(Entity::DATA_FLAGS, Entity::DATA_FLAG_SHEARED, $sheared); // send client data
+    }
+
+    /**
+     * Gets the color of the sheep
+     *
+     * @return int
+     */
+    public function getColor() : int {
+        if(!isset($this->namedtag->Color)){
+            $this->namedtag->Color = new ByteTag(self::NBT_KEY_COLOR, self::getRandomColor());
+        }
+        return (int) $this->namedtag[self::NBT_KEY_COLOR];
+    }
+
+    /**
+     * Set the color of the sheep
+     *
+     * @param int $color
+     */
+    public function setColor(int $color){
+        $this->namedtag->Color = new ByteTag(self::NBT_KEY_COLOR, $color);
+        $this->setDataProperty(self::DATA_COLOUR, self::DATA_TYPE_BYTE, $color);
     }
 
 }

--- a/src/revivalpmmp/pureentities/entity/animal/walking/Sheep.php
+++ b/src/revivalpmmp/pureentities/entity/animal/walking/Sheep.php
@@ -2,6 +2,7 @@
 
 namespace revivalpmmp\pureentities\entity\animal\walking;
 
+use pocketmine\Server;
 use revivalpmmp\pureentities\entity\animal\WalkingAnimal;
 use pocketmine\entity\Colorable;
 use pocketmine\item\Item;
@@ -88,7 +89,7 @@ class Sheep extends WalkingAnimal {
         if($creature instanceof Player){
             if($creature->getInventory()->getItemInHand()->getId() === Item::WHEAT) {
                 return $creature->spawned && $creature->isAlive() && !$creature->closed && $distance <= 49;
-            } elseif($creature->getInventory()->getItemInHand()->getId() === Item::SHEARS && $this instanceof Sheep && $this->getDataFlag(self::DATA_FLAGS, self::DATA_FLAG_SHEARED) === false) {
+            } elseif($distance <= 4 and $creature->getInventory()->getItemInHand()->getId() === Item::SHEARS and self::NETWORK_ID === Data::SHEEP and $this->getDataFlag(self::DATA_FLAGS, self::DATA_FLAG_SHEARED) === false) {
                 $creature->setDataProperty(self::DATA_INTERACTIVE_TAG, self::DATA_TYPE_STRING, "Shear");
             } else {
                 $creature->setDataProperty(self::DATA_INTERACTIVE_TAG, self::DATA_TYPE_STRING, "");
@@ -98,7 +99,11 @@ class Sheep extends WalkingAnimal {
     }
 
     public function getDrops(){
-        return [Item::get(Item::WOOL, self::getColor(), mt_rand(0, 2))];
+        $drops = [];
+        if ($this->getDataFlag(self::DATA_FLAGS, self::DATA_FLAG_SHEARED) === false) {
+            $drops = [Item::get(Item::WOOL, self::getColor(), mt_rand(0, 2))];
+        }
+        return $drops;
     }
 
 }

--- a/src/revivalpmmp/pureentities/entity/animal/walking/Villager.php
+++ b/src/revivalpmmp/pureentities/entity/animal/walking/Villager.php
@@ -18,14 +18,11 @@ class Villager extends WalkingAnimal{
         return "Villager";
     }
 
-    public function initEntity(){
-        parent::initEntity();
-
-        $this->setMaxHealth(10);
-        $this->setHealth(10);
-    }
-    
     public function getDrops(){
         return [];
+    }
+
+    public function getMaxHealth() {
+        return 10;
     }
 }

--- a/src/revivalpmmp/pureentities/entity/monster/flying/Ghast.php
+++ b/src/revivalpmmp/pureentities/entity/monster/flying/Ghast.php
@@ -29,8 +29,6 @@ class Ghast extends FlyingMonster implements ProjectileSource{
         parent::initEntity();
 
         $this->fireProof = true;
-        $this->setMaxHealth(10);
-        $this->setHealth(10);
         $this->setDamage([0, 0, 0, 0]);
     }
 
@@ -81,6 +79,10 @@ class Ghast extends FlyingMonster implements ProjectileSource{
 
     public function getDrops(){
         return [Item::get(Item::GUNPOWDER, 0, mt_rand(0, 2))];
+    }
+
+    public function getMaxHealth() {
+        return 10;
     }
 
 }

--- a/src/revivalpmmp/pureentities/entity/monster/jumping/Slime.php
+++ b/src/revivalpmmp/pureentities/entity/monster/jumping/Slime.php
@@ -27,8 +27,6 @@ class Slime extends JumpingMonster{
     public function initEntity(){
         parent::initEntity();
 
-        $this->setMaxHealth(4);
-        $this->setHealth(4);
         $this->setDamage([0, 2, 2, 3]);
     }
 
@@ -50,5 +48,9 @@ class Slime extends JumpingMonster{
 
     public function getDrops(){
         return [Item::get(Item::SLIMEBALL, 0, mt_rand(0, 2))];
+    }
+
+    public function getMaxHealth() {
+        return 4;
     }
 }

--- a/src/revivalpmmp/pureentities/entity/monster/walking/CaveSpider.php
+++ b/src/revivalpmmp/pureentities/entity/monster/walking/CaveSpider.php
@@ -20,9 +20,6 @@ class CaveSpider extends WalkingMonster{
 
     public function initEntity(){
         parent::initEntity();
-
-        $this->setMaxHealth(12);
-        $this->setHealth(12);
         $this->setDamage([0, 2, 3, 3]);
     }
 
@@ -47,6 +44,10 @@ class CaveSpider extends WalkingMonster{
             break;
         }
         return $drops;
+    }
+
+    public function getMaxHealth() {
+        return 12;
     }
 
 }

--- a/src/revivalpmmp/pureentities/entity/monster/walking/Creeper.php
+++ b/src/revivalpmmp/pureentities/entity/monster/walking/Creeper.php
@@ -180,4 +180,8 @@ class Creeper extends WalkingMonster implements Explosive{
         return [Item::get(Item::GUNPOWDER, 0, mt_rand(0, 2))];
     }
 
+    public function getMaxHealth() {
+        return 20;
+    }
+
 }

--- a/src/revivalpmmp/pureentities/entity/monster/walking/Enderman.php
+++ b/src/revivalpmmp/pureentities/entity/monster/walking/Enderman.php
@@ -44,4 +44,8 @@ class Enderman extends WalkingMonster{
         return [];
     }
 
+    public function getMaxHealth() {
+        return 40;
+    }
+
 }

--- a/src/revivalpmmp/pureentities/entity/monster/walking/Husk.php
+++ b/src/revivalpmmp/pureentities/entity/monster/walking/Husk.php
@@ -80,4 +80,8 @@ class Husk extends WalkingMonster implements Ageable{
         }
         return $drops;
     }
+
+    public function getMaxHealth() {
+        return 20;
+    }
 }

--- a/src/revivalpmmp/pureentities/entity/monster/walking/IronGolem.php
+++ b/src/revivalpmmp/pureentities/entity/monster/walking/IronGolem.php
@@ -22,8 +22,6 @@ class IronGolem extends WalkingMonster{
     }
 
     public function initEntity(){
-        $this->setMaxHealth(100);
-        $this->setHealth(100);
         parent::initEntity();
 
         $this->setFriendly(true);
@@ -57,6 +55,10 @@ class IronGolem extends WalkingMonster{
         array_push($drops, Item::get(Item::IRON_INGOT, 0, mt_rand(3, 5)));
         array_push($drops, Item::get(Item::POPPY, 0, mt_rand(0, 2)));
         return $drops;
+    }
+
+    public function getMaxHealth() {
+        return 100;
     }
 
 }

--- a/src/revivalpmmp/pureentities/entity/monster/walking/PigZombie.php
+++ b/src/revivalpmmp/pureentities/entity/monster/walking/PigZombie.php
@@ -93,4 +93,8 @@ class PigZombie extends WalkingMonster{
         return $drops;
     }
 
+    public function getMaxHealth() {
+        return 20;
+    }
+
 }

--- a/src/revivalpmmp/pureentities/entity/monster/walking/Silverfish.php
+++ b/src/revivalpmmp/pureentities/entity/monster/walking/Silverfish.php
@@ -20,7 +20,7 @@ class Silverfish extends WalkingMonster{
     public function initEntity(){
         parent::initEntity();
 
-        $this->setMaxDamage(8);
+        $this->setMaxDamage(1);
         $this->setDamage([0, 1, 1, 1]);
     }
 
@@ -39,6 +39,10 @@ class Silverfish extends WalkingMonster{
 
     public function getDrops(){
         return [];
+    }
+
+    public function getMaxHealth() {
+        return 8;
     }
 
 }

--- a/src/revivalpmmp/pureentities/entity/monster/walking/Skeleton.php
+++ b/src/revivalpmmp/pureentities/entity/monster/walking/Skeleton.php
@@ -110,4 +110,8 @@ class Skeleton extends WalkingMonster implements ProjectileSource{
         return $drops;
     }
 
+    public function getMaxHealth() {
+        return 20;
+    }
+
 }

--- a/src/revivalpmmp/pureentities/entity/monster/walking/SnowGolem.php
+++ b/src/revivalpmmp/pureentities/entity/monster/walking/SnowGolem.php
@@ -78,4 +78,8 @@ class SnowGolem extends WalkingMonster implements ProjectileSource{
         return [Item::get(Item::SNOWBALL, 0, mt_rand(0, 15))];
     }
 
+    public function getMaxHealth() {
+        return 4;
+    }
+
 }

--- a/src/revivalpmmp/pureentities/entity/monster/walking/Spider.php
+++ b/src/revivalpmmp/pureentities/entity/monster/walking/Spider.php
@@ -24,8 +24,6 @@ class Spider extends WalkingMonster{
     public function initEntity(){
         parent::initEntity();
 
-        $this->setMaxHealth(16);
-        $this->setHealth(16);
         $this->setDamage([0, 2, 2, 3]);
     }
 
@@ -151,6 +149,10 @@ class Spider extends WalkingMonster{
           break;
       }
       return $drops;
+    }
+
+    public function getMaxHealth() {
+        return 16;
     }
 
 }

--- a/src/revivalpmmp/pureentities/entity/monster/walking/Stray.php
+++ b/src/revivalpmmp/pureentities/entity/monster/walking/Stray.php
@@ -110,4 +110,8 @@ class Stray extends WalkingMonster implements ProjectileSource{
         return $drops;
     }
 
+    public function getMaxHealth() {
+        return 20;
+    }
+
 }

--- a/src/revivalpmmp/pureentities/entity/monster/walking/WitherSkeleton.php
+++ b/src/revivalpmmp/pureentities/entity/monster/walking/WitherSkeleton.php
@@ -68,4 +68,8 @@ class WitherSkeleton extends WalkingMonster{
         }
         return $drops;
     }
+
+    public function getMaxHealth() {
+        return 20;
+    }
 }

--- a/src/revivalpmmp/pureentities/entity/monster/walking/Wolf.php
+++ b/src/revivalpmmp/pureentities/entity/monster/walking/Wolf.php
@@ -28,8 +28,6 @@ class Wolf extends WalkingMonster{
             $this->angry = (int) $this->namedtag["Angry"];
         }
 
-        $this->setMaxHealth(8);
-        $this->setHealth(8);
         $this->fireProof = false;
         $this->setDamage([0, 3, 4, 6]);
     }
@@ -74,6 +72,10 @@ class Wolf extends WalkingMonster{
 
     public function getDrops(){
         return [];
+    }
+
+    public function getMaxHealth() {
+        return 8; // but only for wild ones, tamed ones: 20
     }
 
 }

--- a/src/revivalpmmp/pureentities/entity/monster/walking/Zombie.php
+++ b/src/revivalpmmp/pureentities/entity/monster/walking/Zombie.php
@@ -27,7 +27,7 @@ class Zombie extends WalkingMonster implements Ageable{
         if($this->getDataFlag(self::DATA_FLAG_BABY , 0) === null){
             $this->setDataFlag(self::DATA_FLAG_BABY, self::DATA_TYPE_BYTE, 0);
         }
-        $this->setDamage([0, 3, 4, 6]);
+        $this->setDamage([0, 2, 3, 4]);
     }
 
     public function getName(){
@@ -95,5 +95,9 @@ class Zombie extends WalkingMonster implements Ageable{
                 break;
         }
         return $drops;
+    }
+
+    public function getMaxHealth() {
+        return 20;
     }
 }

--- a/src/revivalpmmp/pureentities/entity/monster/walking/ZombieVillager.php
+++ b/src/revivalpmmp/pureentities/entity/monster/walking/ZombieVillager.php
@@ -72,4 +72,8 @@ class ZombieVillager extends WalkingMonster{
       return $drops;
     }
 
+    public function getMaxHealth() {
+        return 20;
+    }
+
 }

--- a/src/revivalpmmp/pureentities/event/EventListener.php
+++ b/src/revivalpmmp/pureentities/event/EventListener.php
@@ -49,7 +49,7 @@ class EventListener implements Listener {
 				}
 				$nbt = new CompoundTag("", [
 					new StringTag("id", Tile::MOB_SPAWNER),
-					new IntTag("EntityId", $item->getId()),
+					new IntTag("EntityId", $item->getDamage()),
 					new IntTag("x", $block->x),
 					new IntTag("y", $block->y),
 					new IntTag("z", $block->z),

--- a/src/revivalpmmp/pureentities/event/EventListener.php
+++ b/src/revivalpmmp/pureentities/event/EventListener.php
@@ -141,15 +141,16 @@ class EventListener implements Listener {
      * @return bool
      */
 	private function shearSheep (Entity $entity, Player $player) : bool {
-        if($entity->getDataFlag(Entity::DATA_FLAGS, Entity::DATA_FLAG_SHEARED) === true) { // already sheared
+        if($entity->isSheared()) { // already sheared
             return false;
         } else { // not sheared yet
-            // drop correct wool color
+            // drop correct wool color by calling getDrops of the entity (the entity knows what to drop!)
             foreach ($entity->getDrops() as $drop) {
                 $player->getLevel()->dropItem($entity, $drop);
             }
-            // set the sheep sheared and reset button text to empty string
-            $entity->setDataFlag(Entity::DATA_FLAGS, Entity::DATA_FLAG_SHEARED, true);
+            // set the sheep sheared
+            $entity->setSheared(true);
+            // reset button text to empty string
             $player->setDataProperty(Entity::DATA_INTERACTIVE_TAG, Entity::DATA_TYPE_STRING, "");
             return true;
         }

--- a/src/revivalpmmp/pureentities/event/EventListener.php
+++ b/src/revivalpmmp/pureentities/event/EventListener.php
@@ -16,6 +16,7 @@ use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\StringTag;
 use pocketmine\network\protocol\Info;
 use pocketmine\network\protocol\InteractPacket;
+use pocketmine\Player;
 use pocketmine\tile\Tile;
 use revivalpmmp\pureentities\entity\animal\walking\Sheep;
 use revivalpmmp\pureentities\PureEntities;
@@ -64,15 +65,8 @@ class EventListener implements Listener {
 		if($packet->pid() === Info::INTERACT_PACKET) {
 			if($packet->action === InteractPacket::ACTION_RIGHT_CLICK) {
 				foreach($player->level->getEntities() as $entity) {
-					if($entity instanceof Sheep && $entity->distance($player) <= 4) {
-						if($entity->getDataFlag(Entity::DATA_FLAGS, Entity::DATA_FLAG_SHEARED) === true) {
-							return false;
-						} else {
-							$player->getLevel()->dropItem($entity, Item::get(Item::WOOL, 0, mt_rand(1, 3)));
-							$entity->setDataFlag(Entity::DATA_FLAGS, Entity::DATA_FLAG_SHEARED, true);
-							$player->setDataProperty(Entity::DATA_INTERACTIVE_TAG, Entity::DATA_TYPE_STRING, "");
-							return true;
-						}
+					if($entity instanceof Sheep and $entity->distance($player) <= 4) {
+                        return $this->shearSheep($entity, $player);
 					}
 				}
 			}
@@ -138,5 +132,27 @@ class EventListener implements Listener {
 			}
 		}
 	}
+
+    /**
+     * Only a small helper method
+     *
+     * @param Entity $entity
+     * @param Player $player
+     * @return bool
+     */
+	private function shearSheep (Entity $entity, Player $player) : bool {
+        if($entity->getDataFlag(Entity::DATA_FLAGS, Entity::DATA_FLAG_SHEARED) === true) { // already sheared
+            return false;
+        } else { // not sheared yet
+            // drop correct wool color
+            foreach ($entity->getDrops() as $drop) {
+                $player->getLevel()->dropItem($entity, $drop);
+            }
+            // set the sheep sheared and reset button text to empty string
+            $entity->setDataFlag(Entity::DATA_FLAGS, Entity::DATA_FLAG_SHEARED, true);
+            $player->setDataProperty(Entity::DATA_INTERACTIVE_TAG, Entity::DATA_TYPE_STRING, "");
+            return true;
+        }
+    }
 
 }

--- a/src/revivalpmmp/pureentities/tile/Spawner.php
+++ b/src/revivalpmmp/pureentities/tile/Spawner.php
@@ -3,6 +3,7 @@
 namespace revivalpmmp\pureentities\tile;
 
 use pocketmine\Player;
+use pocketmine\tile\Tile;
 use revivalpmmp\pureentities\PureEntities;
 use pocketmine\level\format\Chunk as FullChunk;
 use pocketmine\level\Position;
@@ -11,8 +12,9 @@ use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\ShortTag;
 use pocketmine\nbt\tag\StringTag;
 use pocketmine\tile\Spawnable;
+use revivalpmmp\pureentities\task\spawners\BaseSpawner;
 
-class Spawner extends Spawnable{
+class Spawner extends Spawnable {
 
     protected $entityId = -1;
     protected $spawnRange;
@@ -51,6 +53,22 @@ class Spawner extends Spawnable{
             $this->namedtag->RequiredPlayerRange = new ShortTag("RequiredPlayerRange", 20);
         }
 
+        // TODO: add SpawnData: Contains tags to copy to the next spawned entity(s) after spawning. Any of the entity or
+        // mob tags may be used. Note that if a spawner specifies any of these tags, almost all variable data such as mob
+        // equipment, villager profession, sheep wool color, etc., will not be automatically generated, and must also be
+        // manually specified (note that this does not apply to position data, which will be randomized as normal unless
+        // Pos is specified. Similarly, unless Size and Health are specified for a Slime or Magma Cube, these will still
+        // be randomized). This, together with EntityId, also determines the appearance of the miniature entity spinning
+        // in the spawner cage. Note: this tag is optional: if it does not exist, the next spawned entity will use
+        // the default vanilla spawning properties for this mob, including potentially randomized armor (this is true even
+        // if SpawnPotentials does exist). Warning: If SpawnPotentials exists, this tag will get overwritten after the
+        // next spawning attempt: see above for more details.
+        if (!isset($this->namedtag->SpawnData)) {
+            $this->namedtag->SpawnData = new CompoundTag("SpawnData", [new IntTag("EntityId", $this->entityId)]);
+        }
+
+        // TODO: add SpawnCount: How many mobs to attempt to spawn each time. Note: Requires the MinSpawnDelay property to also be set.
+
         $this->spawnRange = $this->namedtag["SpawnRange"];
         $this->minSpawnDelay = $this->namedtag["MinSpawnDelay"];
         $this->maxSpawnDelay = $this->namedtag["MaxSpawnDelay"];
@@ -81,12 +99,11 @@ class Spawner extends Spawnable{
             }
 
             if($isValid && count($list) <= $this->maxNearbyEntities){
-                $pos = new Position(
-                    $this->x + mt_rand(-$this->spawnRange, $this->spawnRange),
-                    $this->y,
-                    $this->z + mt_rand(-$this->spawnRange, $this->spawnRange),
-                    $this->level
-                );
+                $y = $this->level->getHighestBlockAt($this->x, $this->z);
+                $x = $this->x + mt_rand(-$this->spawnRange, $this->spawnRange);
+                $z = $this->z + mt_rand(-$this->spawnRange, $this->spawnRange);
+                $pos = PureEntities::getFirstAirAbovePosition($x, $y, $z, $this->level);
+                $pos->y += BaseSpawner::HEIGHTS[$this->entityId];
                 $entity = PureEntities::create($this->entityId, $pos);
                 if($entity != null){
                     $entity->spawnToAll();
@@ -105,17 +122,22 @@ class Spawner extends Spawnable{
         $this->namedtag->MaxSpawnDelay = new ShortTag("MaxSpawnDelay", $this->maxSpawnDelay);
         $this->namedtag->MaxNearbyEntities = new ShortTag("MaxNearbyEntities", $this->maxNearbyEntities);
         $this->namedtag->RequiredPlayerRange = new ShortTag("RequiredPlayerRange", $this->requiredPlayerRange);
+        $this->namedtag->SpawnData = new CompoundTag("SpawnData", [new IntTag("EntityId", $this->entityId)]);
     }
 
     public function getSpawnCompound(){
         return new CompoundTag("", [
-            new StringTag("id", "MobSpawner"),
+            new StringTag("id", Tile::MOB_SPAWNER),
             new IntTag("EntityId", $this->entityId)
         ]);
     }
 
     public function setSpawnEntityType(int $entityId){
         $this->entityId = $entityId;
+        $this->namedtag->EntityId = new ShortTag("EntityId", $this->entityId);
+        $this->namedtag->SpawnData = new CompoundTag("SpawnData", [
+            new IntTag("EntityId", $this->entityId)
+        ]);
         $this->spawnToAll();
     }
 


### PR DESCRIPTION
<!-- replace the ' ' with 'x' in the brackets -->
- [x] This PR actually submits something - don't use this system as a messaging service!
- [x] This PR isn't duplicated - you can check if it is by scanning the small list - link is on the navigation bar for this repository.
- [x] This PR includes appropriate markdown for sections - e.g. code blocks for suggested code.
- [x] This PR description and comments in code is understandable - feel free to use your native language to write if you are not comfortable with English.
- [x] This PR has a single branch for itself in your fork - don't just commit to the master branch of your repository!
- [x] This PR has comments written in clear English - please don't write unreadable comments just for your eyes.

<!-- PR DESCRIPTION - write a bit about what you've achieved in this pull request. -->
## Pull Request description
This PR fixes an internal bug where color and sheared status of a sheep are not stored in NBT. This is not so nice, when it's reloaded from chunk data because the color will change and it appears as not sheared. This is fixed now. Also removed setHealth and setMaxHealth from initEntity. It was mainly wrong, because when entity is reloaded from NBT data the health got reset to the default value.

<!-- PR branch - what branch is being changed? -->
## Changed Branch
1.0.0-bug-fixes

<!-- OPTIONAL INFORMATION - use this section for posting crash dumps, backtraces or other files(please use code markdown!) -->
## Optional information
I'll do the health changes to all the other entities too later.