### PR TITLE
Fix Monster Spawners

### DIFF
--- a/src/revivalpmmp/pureentities/PureEntities.php
+++ b/src/revivalpmmp/pureentities/PureEntities.php
@@ -20,6 +20,7 @@
 
 namespace revivalpmmp\pureentities;
 
+use pocketmine\block\BlockFactory;
 use pocketmine\command\Command;
 use pocketmine\command\CommandExecutor;
 use pocketmine\command\CommandSender;
@@ -35,6 +36,7 @@ use pocketmine\Server;
 use pocketmine\ThreadManager;
 use pocketmine\tile\Tile;
 use pocketmine\utils\TextFormat;
+use revivalpmmp\pureentities\block\MonsterSpawnerPEX;
 use revivalpmmp\pureentities\data\Color;
 use revivalpmmp\pureentities\entity\animal\flying\Bat;
 use revivalpmmp\pureentities\entity\animal\flying\Parrot;
@@ -206,7 +208,7 @@ class PureEntities extends PluginBase implements CommandExecutor{
 		}
 
 		Tile::registerTile(MobSpawner::class);
-
+		BlockFactory::registerBlock(new MonsterSpawnerPEX(), true);
 
 		$this->saveDefaultConfig();
 

--- a/src/revivalpmmp/pureentities/PureEntities.php
+++ b/src/revivalpmmp/pureentities/PureEntities.php
@@ -89,7 +89,7 @@ use revivalpmmp\pureentities\features\IntfTameable;
 use revivalpmmp\pureentities\task\AutoSpawnTask;
 use revivalpmmp\pureentities\task\EndermanLookingTask;
 use revivalpmmp\pureentities\task\InteractionTask;
-use revivalpmmp\pureentities\tile\Spawner;
+use revivalpmmp\pureentities\tile\MobSpawner;
 use revivalpmmp\pureentities\utils\MobEquipper;
 
 class PureEntities extends PluginBase implements CommandExecutor{
@@ -205,7 +205,8 @@ class PureEntities extends PluginBase implements CommandExecutor{
 			}
 		}
 
-		Tile::registerTile(Spawner::class);
+		Tile::registerTile(MobSpawner::class);
+
 
 		$this->saveDefaultConfig();
 

--- a/src/revivalpmmp/pureentities/block/MonsterSpawnerPEX.php
+++ b/src/revivalpmmp/pureentities/block/MonsterSpawnerPEX.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * PureEntitiesX: Mob AI Plugin for PMMP
+ * Copyright (C)  2018 RevivalPMMP
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Thanks to CortexPE and NycuRO for some helpful information in TeaSpoon
+ * The framework for this was based on their MonsterSpawner
+ *
+ *https://github.com/CortexPE/TeaSpoon/blob/master/src/CortexPE/block/MonsterSpawner.php
+ */
+
+namespace revivalpmmp\pureentities\block;
+
+
+use pocketmine\block\Block;
+use pocketmine\block\MonsterSpawner;
+use pocketmine\item\Item;
+use pocketmine\math\Vector3;
+use pocketmine\Player;
+use pocketmine\tile\Tile;
+use revivalpmmp\pureentities\tile\MobSpawner;
+
+class MonsterSpawnerPEX extends MonsterSpawner{
+	private $entityId = -1;
+
+	public function __construct(int $meta = 0){
+		$this->meta = $meta;
+	}
+
+	public function canBeActivated(): bool{
+		return true;
+	}
+
+	public function onActivate(Item $item, Player $player = null) : bool{
+		if($item->getId() !== Item::SPAWN_EGG){
+			return false;
+		}
+		$this->entityId = $item->getDamage();
+		$this->generateSpawnerTile();
+		return true;
+	}
+
+	public function place(Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, Player $player = null) : bool{
+		$return = parent::place($item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+
+		if($item->getDamage() > 9){
+			$this->meta = 0;
+			$this->entityId = $item->getDamage();
+			$this->getLevel()->setBlock($this, $this, true, false);
+			$this->generateSpawnerTile();
+		}
+
+		return $return;
+	}
+
+	private function generateSpawnerTile() {
+		$tile = $this->getLevel()->getTile($this);
+		if(!$tile instanceof MobSpawner){
+			$nbt = MobSpawner::createNBT($this);
+			$nbt->setString(Tile::TAG_ID, Tile::MOB_SPAWNER);
+
+			/** @var MobSpawner $spawnerTile */
+			$tile = Tile::createTile("MobSpawner", $this->getLevel(), $nbt);
+		}
+		$tile->setSpawnEntityType($this->entityId);
+	}
+
+	public function getSilkTouchDrops(Item $item) : array{
+		return [];
+	}
+}

--- a/src/revivalpmmp/pureentities/block/MonsterSpawnerPEX.php
+++ b/src/revivalpmmp/pureentities/block/MonsterSpawnerPEX.php
@@ -46,6 +46,16 @@ class MonsterSpawnerPEX extends MonsterSpawner{
 		return true;
 	}
 
+
+	/**
+	 * This method replaces the event listener that was being used for spawn eggs.
+	 * It will need to be updated in the future when additional tags are supported.
+	 *
+	 *
+	 * @param Item        $item
+	 * @param Player|null $player
+	 * @return bool
+	 */
 	public function onActivate(Item $item, Player $player = null) : bool{
 		if($item->getId() !== Item::SPAWN_EGG){
 			return false;
@@ -55,6 +65,20 @@ class MonsterSpawnerPEX extends MonsterSpawner{
 		return true;
 	}
 
+
+	/**
+	 * Additional method for updating MobSpawner tile detals.  This will also need
+	 * to be updated in the future when additional tag info is supported.
+	 *
+	 *
+	 * @param Item        $item
+	 * @param Block       $blockReplace
+	 * @param Block       $blockClicked
+	 * @param int         $face
+	 * @param Vector3     $clickVector
+	 * @param Player|null $player
+	 * @return bool
+	 */
 	public function place(Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, Player $player = null) : bool{
 		$return = parent::place($item, $blockReplace, $blockClicked, $face, $clickVector, $player);
 
@@ -68,6 +92,11 @@ class MonsterSpawnerPEX extends MonsterSpawner{
 		return $return;
 	}
 
+
+	/**
+	 * Checks for the presence of a MobSpawner in the same location as the MonsterSpawner block.
+	 * If not there, it creates one, then updates the EntityId.
+	 */
 	private function generateSpawnerTile() {
 		$tile = $this->getLevel()->getTile($this);
 		if(!$tile instanceof MobSpawner){
@@ -80,6 +109,14 @@ class MonsterSpawnerPEX extends MonsterSpawner{
 		$tile->setSpawnEntityType($this->entityId);
 	}
 
+
+	/**
+	 * Vanilla MonsterSpanwers don't drop themselves under any circumstance.  May add the ability
+	 * drop itself through config options.
+	 *
+	 * @param Item $item
+	 * @return array
+	 */
 	public function getSilkTouchDrops(Item $item) : array{
 		return [];
 	}

--- a/src/revivalpmmp/pureentities/event/EventListener.php
+++ b/src/revivalpmmp/pureentities/event/EventListener.php
@@ -23,21 +23,15 @@ namespace revivalpmmp\pureentities\event;
 use pocketmine\block\Air;
 use pocketmine\event\block\BlockPlaceEvent;
 use pocketmine\event\Listener;
-use pocketmine\event\player\PlayerInteractEvent;
 use pocketmine\event\player\PlayerJoinEvent;
 use pocketmine\event\player\PlayerQuitEvent;
 use pocketmine\event\server\DataPacketReceiveEvent;
 use pocketmine\item\Item;
 use pocketmine\level\Position;
 use pocketmine\math\Vector3;
-use pocketmine\nbt\tag\CompoundTag;
-use pocketmine\nbt\tag\IntTag;
-use pocketmine\nbt\tag\StringTag;
 use pocketmine\network\mcpe\protocol\InventoryTransactionPacket;
 use pocketmine\network\mcpe\protocol\ProtocolInfo;
-use pocketmine\tile\Tile;
 use revivalpmmp\pureentities\data\Color;
-use revivalpmmp\pureentities\data\NBTConst;
 use revivalpmmp\pureentities\entity\animal\walking\Cow;
 use revivalpmmp\pureentities\entity\animal\walking\Ocelot;
 use revivalpmmp\pureentities\entity\animal\walking\Sheep;
@@ -52,7 +46,6 @@ use revivalpmmp\pureentities\PluginConfiguration;
 use revivalpmmp\pureentities\PureEntities;
 use revivalpmmp\pureentities\task\delayed\SetTamedOwnerTask;
 use revivalpmmp\pureentities\task\delayed\ShowMobEquipmentTask;
-use revivalpmmp\pureentities\tile\Spawner;
 
 class EventListener implements Listener{
 
@@ -60,36 +53,6 @@ class EventListener implements Listener{
 
 	public function __construct(PureEntities $plugin){
 		$this->plugin = $plugin;
-	}
-
-	public function PlayerInteractEvent(PlayerInteractEvent $ev){
-		if($ev->getFace() == 255 || $ev->getAction() != PlayerInteractEvent::RIGHT_CLICK_BLOCK){
-			return;
-		}
-
-		$item = $ev->getItem();
-		$block = $ev->getBlock();
-		if($item->getId() === Item::SPAWN_EGG && $block->getId() == Item::MONSTER_SPAWNER){
-			$ev->setCancelled();
-
-			$tile = $block->level->getTile($block);
-			if($tile != null && $tile instanceof Spawner){
-				PureEntities::logOutput("EventListener:: Calling setSpawnEntityType");
-				$tile->setSpawnEntityType($item->getDamage());
-			}else{
-				if($tile != null){
-					$tile->close();
-				}
-				PureEntities::logOutput("Creating New Spawner");
-				$nbt = new CompoundTag("");
-				$nbt->setString(Tile::TAG_ID, Tile::MOB_SPAWNER);
-				$nbt->setInt(NBTConst::NBT_KEY_SPAWNER_ENTITY_ID, $item->getDamage());
-				$nbt->setInt(Tile::TAG_X, $block->x);
-				$nbt->setInt(Tile::TAG_Y, $block->y);
-				$nbt->setInt(Tile::TAG_Z, $block->z);
-				new Spawner($block->getLevel(), $nbt);
-			}
-		}
 	}
 
 	/**

--- a/src/revivalpmmp/pureentities/tile/MobSpawner.php
+++ b/src/revivalpmmp/pureentities/tile/MobSpawner.php
@@ -29,7 +29,7 @@ use revivalpmmp\pureentities\PureEntities;
 use pocketmine\nbt\tag\CompoundTag;
 use pocketmine\tile\Spawnable;
 
-class Spawner extends Spawnable{
+class MobSpawner extends Spawnable{
 
 	protected $entityId = -1;
 	protected $spawnRange = 8;
@@ -47,7 +47,7 @@ class Spawner extends Spawnable{
 		parent::__construct($level, $nbt);
 
 		$this->scheduleUpdate();
-		PureEntities::logOutput("Spawner Created with EntityID of $this->entityId");
+		PureEntities::logOutput("MobSpawner Created with EntityID of $this->entityId");
 	}
 
 	public function onUpdate() : bool{
@@ -82,7 +82,7 @@ class Spawner extends Spawnable{
 				$pos->y += Data::HEIGHTS[$this->entityId];
 				$entity = PureEntities::create($this->entityId, $pos);
 				if($entity != null){
-					PureEntities::logOutput("Spawner: spawn $entity to $pos");
+					PureEntities::logOutput("MobSpawner: spawn $entity to $pos");
 					$entity->spawnToAll();
 				}
 			}

--- a/src/revivalpmmp/pureentities/tile/Spawner.php
+++ b/src/revivalpmmp/pureentities/tile/Spawner.php
@@ -195,10 +195,10 @@ class Spawner extends Spawnable{
 			// the default vanilla spawning properties for this mob, including potentially randomized armor (this is true even
 			// if SpawnPotentials does exist). Warning: If SpawnPotentials exists, this tag will get overwritten after the
 			// next spawning attempt: see above for more details.
-			if(!$nbt->hasTag(NBTConst::NBT_KEY_SPAWNER_SPAWN_DATA)){
-				$spawnData = new CompoundTag(NBTConst::NBT_KEY_SPAWNER_SPAWN_DATA, [new IntTag(NBTConst::NBT_KEY_SPAWNER_ENTITY_ID, $this->entityId)]);
-				$nbt->setTag($spawnData);
-			}
+			// if(!$nbt->hasTag(NBTConst::NBT_KEY_SPAWNER_SPAWN_DATA)){
+			//	 $spawnData = new CompoundTag(NBTConst::NBT_KEY_SPAWNER_SPAWN_DATA, [new IntTag(NBTConst::NBT_KEY_SPAWNER_ENTITY_ID, $this->entityId)]);
+			//	 $nbt->setTag($spawnData);
+			// }
 
 		}
 	}

--- a/src/revivalpmmp/pureentities/tile/Spawner.php
+++ b/src/revivalpmmp/pureentities/tile/Spawner.php
@@ -111,7 +111,7 @@ class Spawner extends Spawnable{
 	}
 
 	public function setMaxSpawnDelay(int $maxDelay){
-		if($this->minSpawnDelay > $maxDelay){
+		if($this->minSpawnDelay > $maxDelay or $maxDelay === 0){
 			return;
 		}
 

--- a/src/revivalpmmp/pureentities/tile/Spawner.php
+++ b/src/revivalpmmp/pureentities/tile/Spawner.php
@@ -169,6 +169,10 @@ class Spawner extends Spawnable{
 				$this->maxSpawnDelay = $nbt->getShort(NBTConst::NBT_KEY_SPAWNER_MAX_SPAWN_DELAY, 800, true);
 			}
 
+			if($nbt->hasTag(NBTConst::NBT_KEY_SPAWNER_DELAY)){
+				$this->delay = $nbt->getShort(NBTConst::NBT_KEY_SPAWNER_DELAY, 0, true);
+			}
+
 			if($nbt->hasTag(NBTConst::NBT_KEY_SPAWNER_MAX_NEARBY_ENTITIES)){
 				$this->maxNearbyEntities = $nbt->getShort(NBTConst::NBT_KEY_SPAWNER_MAX_NEARBY_ENTITIES, 6, true);
 			}

--- a/src/revivalpmmp/pureentities/tile/Spawner.php
+++ b/src/revivalpmmp/pureentities/tile/Spawner.php
@@ -136,7 +136,18 @@ class Spawner extends Spawnable{
 	}
 
 	public function addAdditionalSpawnData(CompoundTag $nbt) : void{
+		$nbt->setByte(NBTConst::NBT_KEY_SPAWNER_IS_MOVABLE, 1);
+		$nbt->setShort(NBTConst::NBT_KEY_SPAWNER_DELAY, 0);
+		$nbt->setShort(NBTConst::NBT_KEY_SPAWNER_MAX_NEARBY_ENTITIES, $this->maxNearbyEntities);
+		$nbt->setShort(NBTConst::NBT_KEY_SPAWNER_MAX_SPAWN_DELAY, $this->maxSpawnDelay);
+		$nbt->setShort(NBTConst::NBT_KEY_SPAWNER_MIN_SPAWN_DELAY, $this->minSpawnDelay);
+		$nbt->setShort(NBTConst::NBT_KEY_SPAWNER_REQUIRED_PLAYER_RANGE, $this->requiredPlayerRange);
+		$nbt->setShort(NBTConst::NBT_KEY_SPAWNER_SPAWN_COUNT, $this->spawnCount);
+		$nbt->setShort(NBTConst::NBT_KEY_SPAWNER_SPAWN_RANGE, $this->spawnRange);
 		$nbt->setInt(NBTConst::NBT_KEY_SPAWNER_ENTITY_ID, $this->entityId);
+		//$spawnData = new CompoundTag(NBTConst::NBT_KEY_SPAWNER_SPAWN_DATA, [new StringTag("id", $this->entityId)]);
+		//$nbt->setTag($spawnData);
+		$this->scheduleUpdate();
 	}
 
 	public function readSaveData(CompoundTag $nbt) : void{
@@ -190,21 +201,7 @@ class Spawner extends Spawnable{
 
 	public function writeSaveData(CompoundTag $nbt) : void{
 		if(PluginConfiguration::getInstance()->getEnableNBT()){
-
-			$nbt->setByte(NBTConst::NBT_KEY_SPAWNER_IS_MOVABLE, 1);
-			$nbt->setShort(NBTConst::NBT_KEY_SPAWNER_DELAY, 0);
-			$nbt->setShort(NBTConst::NBT_KEY_SPAWNER_MAX_NEARBY_ENTITIES, $this->maxNearbyEntities);
-			$nbt->setShort(NBTConst::NBT_KEY_SPAWNER_MAX_SPAWN_DELAY, $this->maxSpawnDelay);
-			$nbt->setShort(NBTConst::NBT_KEY_SPAWNER_MIN_SPAWN_DELAY, $this->minSpawnDelay);
-			$nbt->setShort(NBTConst::NBT_KEY_SPAWNER_REQUIRED_PLAYER_RANGE, $this->requiredPlayerRange);
-			$nbt->setShort(NBTConst::NBT_KEY_SPAWNER_SPAWN_COUNT, 0);
-			$nbt->setShort(NBTConst::NBT_KEY_SPAWNER_SPAWN_RANGE, $this->spawnRange);
-			$nbt->setInt(NBTConst::NBT_KEY_SPAWNER_ENTITY_ID, $this->entityId);
-			$nbt->setFloat(NBTConst::NBT_KEY_SPAWNER_DISPLAY_ENTITY_HEIGHT, 1);
-			$nbt->setFloat(NBTConst::NBT_KEY_SPAWNER_DISPLAY_ENTITY_SCALE, 1);
-			$nbt->setFloat(NBTConst::NBT_KEY_SPAWNER_DISPLAY_ENTITY_WIDTH, 0.5);
-			$spawnData = new CompoundTag(NBTConst::NBT_KEY_SPAWNER_SPAWN_DATA, [new IntTag(NBTConst::NBT_KEY_SPAWNER_ENTITY_ID, $this->entityId)]);
-			$nbt->setTag($spawnData);
+			$this->addAdditionalSpawnData($nbt);
 		}
 	}
 

--- a/src/revivalpmmp/pureentities/tile/Spawner.php
+++ b/src/revivalpmmp/pureentities/tile/Spawner.php
@@ -27,7 +27,6 @@ use revivalpmmp\pureentities\data\NBTConst;
 use revivalpmmp\pureentities\PluginConfiguration;
 use revivalpmmp\pureentities\PureEntities;
 use pocketmine\nbt\tag\CompoundTag;
-use pocketmine\nbt\tag\IntTag;
 use pocketmine\tile\Spawnable;
 
 class Spawner extends Spawnable{

--- a/src/revivalpmmp/pureentities/tile/Spawner.php
+++ b/src/revivalpmmp/pureentities/tile/Spawner.php
@@ -95,9 +95,10 @@ class Spawner extends Spawnable{
 		PureEntities::logOutput("setSpawnEntityType called with EntityID of $entityId");
 		$this->entityId = $entityId;
 		if(PluginConfiguration::getInstance()->getEnableNBT()){
-			$this->saveNBT();
+			$this->writeSaveData($tag = new CompoundTag());
 		}
-		$this->spawnToAll();
+		$this->onChanged();
+		$this->scheduleUpdate();
 	}
 
 	public function setMinSpawnDelay(int $minDelay){

--- a/src/revivalpmmp/pureentities/tile/Spawner.php
+++ b/src/revivalpmmp/pureentities/tile/Spawner.php
@@ -41,6 +41,7 @@ class Spawner extends Spawnable{
 
 	protected $minSpawnDelay = 200;
 	protected $maxSpawnDelay = 800;
+	protected $spawnCount = 0;
 
 	public function __construct(Level $level, CompoundTag $nbt){
 
@@ -165,6 +166,10 @@ class Spawner extends Spawnable{
 				$this->requiredPlayerRange = $nbt->getShort(NBTConst::NBT_KEY_SPAWNER_REQUIRED_PLAYER_RANGE, 16);
 			}
 
+			if($nbt->hasTag(NBTConst::NBT_KEY_SPAWNER_SPAWN_COUNT)){
+				$this->spawnCount = $nbt->getShort(NBTConst::NBT_KEY_SPAWNER_SPAWN_COUNT, 0, true);
+			}
+
 			// TODO: add SpawnData: Contains tags to copy to the next spawned entity(s) after spawning. Any of the entity or
 			// mob tags may be used. Note that if a spawner specifies any of these tags, almost all variable data such as mob
 			// equipment, villager profession, sheep wool color, etc., will not be automatically generated, and must also be
@@ -180,7 +185,6 @@ class Spawner extends Spawnable{
 				$nbt->setTag($spawnData);
 			}
 
-			// TODO: add SpawnCount: How many mobs to attempt to spawn each time. Note: Requires the MinSpawnDelay property to also be set.
 		}
 	}
 
@@ -204,4 +208,7 @@ class Spawner extends Spawnable{
 		}
 	}
 
+	public function getSpawnCount() : int{
+		return $this->spawnCount;
+	}
 }


### PR DESCRIPTION
<!-- replace the ' ' with 'x' in the brackets -->
- [x] This PR actually submits something - don't use this system as a messaging service!
- [x] This PR isn't duplicated - you can check if it is by scanning the small list - link is on the navigation bar for this repository.
- [x] This PR includes appropriate markdown for sections - e.g. code blocks for suggested code.
- [x] This PR description and comments in code is understandable - feel free to use your native language to write if you are not comfortable with English.
- [ x This PR has a single branch for itself in your fork - don't just commit to the master branch of your repository!
- [x] This PR has comments written in clear English - please don't write unreadable comments just for your eyes.

<!-- PR DESCRIPTION - write a bit about what you've achieved in this pull request. -->
## Pull Request description
This will fix several existing bugs with Monser Spawners where the mob being spawned doesn't show up inside the Monster Spawner and server restarts can cause the Spawner to stop working.

<!-- PR branch - what branch is being changed? -->
## Changed Branch
Master

<!-- OPTIONAL INFORMATION - use this section for posting crash dumps, backtraces or other files(please use code markdown!) -->
## Optional information
Details of what was changed are included in each commit message.  Most notable are:

 - Addition of a new block class: MonsterSpawnerPEX
 - Refactor of Spawner to MobSpawner
 - Update MobSpawner::setSpawnEntityType

The biggest complication here was that the game client displays the mob inside the Monster Spawner based on the NBT of the MobSpawner tile.  Because the MobSpawner class was previously called Spawner, game clients didn't recognize the NBT Tag ` id ` as a spawner.