### PR TITLE
Fix crash when Spider would attack player

### DIFF
--- a/src/revivalpmmp/pureentities/entity/BaseEntity.php
+++ b/src/revivalpmmp/pureentities/entity/BaseEntity.php
@@ -464,6 +464,7 @@ abstract class BaseEntity extends Creature{
 		if($player->isClosed()) return [];
 		foreach($player->getLevel()->getEntities() as $entity){
 			if($entity instanceof IntfTameable and
+				$entity->getOwner() !== null and
 				$entity->isTamed() and
 				strcasecmp($entity->getOwner()->getName(), $player->getName()) === 0 and
 				$entity->isAlive()


### PR DESCRIPTION
<!-- replace the ' ' with 'x' in the brackets -->
- [x] This PR actually submits something - don't use this system as a messaging service!
- [x] This PR isn't duplicated - you can check if it is by scanning the small list - link is on the navigation bar for this repository.
- [x] This PR includes appropriate markdown for sections - e.g. code blocks for suggested code.
- [x] This PR description and comments in code is understandable - feel free to use your native language to write if you are not comfortable with English.
- [x] This PR has a single branch for itself in your fork - don't just commit to the master branch of your repository!
- [x] This PR has comments written in clear English - please don't write unreadable comments just for your eyes.

<!-- PR DESCRIPTION - write a bit about what you've achieved in this pull request. -->
## Pull Request description
Found a crash when attempting to get the name of an entity owner, in this case, an attacking Spider.  Used similar nomenclature to similar code in the same file to check if getOwner() returned null, thus followed form and style of existing code.

<!-- PR branch - what branch is being changed? -->
## Changed Branch
Branched from 'master'.

<!-- OPTIONAL INFORMATION - use this section for posting crash dumps, backtraces or other files(please use code markdown!) -->
## Optional information
Crashdump of example is attached.

[Sun_Jan_26-09.13.56-CST_2020.log](https://github.com/RevivalPMMP/PureEntitiesX/files/4113633/Sun_Jan_26-09.13.56-CST_2020.log)
